### PR TITLE
fix helm diff: HELM_HOME usable by non-root user

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -28,9 +28,12 @@ RUN curl -o /usr/local/bin/sops -L https://github.com/mozilla/sops/releases/down
 RUN chmod +x /usr/local/bin/sops
 
 # Install Helm plugins
+ENV HELM_HOME=/root/.helm
 RUN helm init --client-only
 RUN helm plugin install https://github.com/viglesiasce/helm-gcs.git
 RUN helm plugin install https://github.com/databus23/helm-diff
+# Give anyone permission to the $HELM_HOME, so we can run image as any user:
+RUN chmod 777 -fR /root /root/.helm
 
 # Install Terraform
 RUN mkdir /terraform


### PR DESCRIPTION
## Before

### (as root)
```shell
$ docker run --rm -it eu.gcr.io/pagero-public/k8s:v0.8 helm plugin list
NAME	VERSION 	DESCRIPTION
diff	2.11.0+5	Preview helm upgrade changes as a diff
gcs 	0.2.0   	Provides Google Cloud Storage protocol suppo...
```

### (as yourself)
```shell
$ docker run --rm -it --user $(id -u):$(id -g) eu.gcr.io/pagero-public/k8s:v0.9 helm plugin list
NAME	VERSION	DESCRIPTION
```

## After 

### (as root)

```shell
$ docker run --rm -it eu.gcr.io/pagero-public/k8s:v0.10 helm plugin list
NAME	VERSION	DESCRIPTION
diff	3.1.1  	Preview helm upgrade changes as a diff
gcs 	0.2.0  	Provides Google Cloud Storage protocol suppo...
```

### (as yourself)
```shell
$ docker run --rm -it --user $(id -u):$(id -g) eu.gcr.io/pagero-public/k8s:v0.10 helm plugin list
NAME	VERSION	DESCRIPTION
diff	3.1.1  	Preview helm upgrade changes as a diff
gcs 	0.2.0  	Provides Google Cloud Storage protocol suppo...
```